### PR TITLE
Setup of the test. Added Mockito 2.7.7 dependency

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -37,6 +37,11 @@
             <artifactId>jbcrypt</artifactId>
             <version>0.4</version>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.7.7</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/java/src/META-INF/persistence.xml
+++ b/java/src/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <!DOCTYPE doc [
-        <!ENTITY login SYSTEM "java/src/META-INF/db_login.xml" >
+        <!ENTITY login SYSTEM "src/META-INF/db_login.xml" >
         ] >
 
 <persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence"

--- a/java/tests/base/BaseTest.java
+++ b/java/tests/base/BaseTest.java
@@ -1,0 +1,18 @@
+package base;
+
+import org.junit.Before;
+
+public class BaseTest {
+
+  /*
+   All tests in the system should extend this tests class, which sets properties that are required
+   for the tests to work in the same way the actual system will run.
+  */
+
+
+  @Before
+  public void setUpBaseTest() {
+    System.setProperty("javax.xml.accessExternalDTD", "all");
+  }
+
+}


### PR DESCRIPTION
- Added a base test, for setup of system properties needed for the test environment to run in the same way that the system environment will run. All tests need to extend this
- Fixed the path of the database login file
- Added a Mockito 2.7.7 dependecy. Mockito should be used for testing DatabaseObjectManagers such that the production database is not changed during the tests.