### PR TITLE
Fix/add exercise to multiple topics/api

### DIFF
--- a/java/src/api/helpers/JSONCheckerHelper.java
+++ b/java/src/api/helpers/JSONCheckerHelper.java
@@ -27,12 +27,13 @@ public class JSONCheckerHelper {
   }
 
   /**
-   * A helper for checking if the given HttpRequest contains the required fields in the JSON,
-   * and getting the fields if they all exist
+   * A helper for checking if the given HttpRequest contains the required field in the JSON,
+   * and getting the field if it exists
    * @param httpRequest The HttpRequest to check
    * @param field Field to get
-   * @param tClass Class of the values in the fields
-   * @throws APIBadRequestException Thrown if the JSONObject does not contain one of the fields
+   * @param tClass Class of the value in the field
+   * @throws APIBadRequestException Thrown if the JSONObject does not contain the field, or the value
+   * of the field is not of the correct type.
    * @throws APIErrorException Thrown if there is a IOException while reading the content
    * @return Value of field, casted to tClass
    */

--- a/java/src/api/helpers/JSONCheckerHelper.java
+++ b/java/src/api/helpers/JSONCheckerHelper.java
@@ -4,7 +4,10 @@ import static api.helpers.EntityContentHelper.checkAndGetEntityContent;
 
 import api.exceptions.APIBadRequestException;
 import api.exceptions.APIErrorException;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.http.HttpRequest;
+import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -49,6 +52,34 @@ public class JSONCheckerHelper {
     }
     catch (ClassCastException cce){
       throw new APIBadRequestException(field + " must be " + tClass.getTypeName());
+    }
+  }
+
+  /**
+   * A helper for checking if the given HttpRequest contains the required field in the JSON,
+   * and getting the values in the field as a list if the field exists
+   * @param httpRequest The HttpRequest to check
+   * @param field Field to get
+   * @param tClass Class of the values in the field
+   * @throws APIBadRequestException Thrown if the JSONObject does not contain the field, or the field
+   * is not an array where all the elements are of the correct type.
+   * @throws APIErrorException Thrown if there is a IOException while reading the content
+   * @return Value of field, casted to tClass
+   */
+  public static <T> List<T> getJSONArray(HttpRequest httpRequest, Class<T> tClass,
+      String field) throws APIBadRequestException, APIErrorException{
+    String requestContent = checkAndGetEntityContent(httpRequest);
+    JSONObject jsonObject = checkAndGetJSON(requestContent);
+    if (!jsonObject.has(field)){
+      throw new APIBadRequestException(field + " must be set");
+    }
+    try{
+      ArrayList<T> ret = new ArrayList<>();
+      jsonObject.getJSONArray(field).iterator().forEachRemaining(o -> ret.add(tClass.cast(o)));
+      return ret;
+    }
+    catch (ClassCastException cce){
+      throw new APIBadRequestException(field + " must be array of " + tClass.getTypeName());
     }
   }
 

--- a/java/src/data/exercise/Exercise.java
+++ b/java/src/data/exercise/Exercise.java
@@ -106,6 +106,19 @@ public class Exercise extends AbstractBaseEntity{
     this.solution = solution;
   }
 
+  /**
+   * Adds this exercise to all topics in a collection
+   *
+   * @param topics the topics to add this exercise to
+   */
+  public void addToTopics(Collection<Topic> topics){
+    topics.forEach(topic ->
+        {topic.addExercise(this);
+         topic.update();
+        }
+    );
+  }
+
   public JSONObject createAbout(){
     JSONObject response = new JSONObject();
     response.put("id", id);


### PR DESCRIPTION
Changes the AddExercise API to take an array of topic id's instead of a single id.

Note that the topic field name has changed from "topicID" to "topicIDs".

Still doesn't have any tests.