### PR TITLE
Improved performance for Image upload in PDF conversion

### DIFF
--- a/java/src/pdf/PDFParser.java
+++ b/java/src/pdf/PDFParser.java
@@ -22,6 +22,7 @@ import pdf.dom.StyleHandler;
 
 
 public class PDFParser {
+
   /**
    * Converts the PDDocument given in to HTML
    *
@@ -98,6 +99,16 @@ public class PDFParser {
       // Fix a graphical bug with nodes with text content starting with a dash
       if (!node.getTextContent().isEmpty() && node.getTextContent().contains("-")) {
         GraphicFixer.fixDashNode(node);
+      }
+
+      // Fixes a bug where some text would have a gigantic font-size
+      StyleHandler styleHandler = new StyleHandler(node);
+      if (styleHandler.hasStyleTag("font-size") && styleHandler.hasStyleTag("line-height")
+          && styleHandler.getFloatValue("font-size") > styleHandler.getFloatValue("line-height")) {
+        // Multiply with 0.84 due to the line including both high and low letters
+        styleHandler
+            .setStyleTag("font-size", styleHandler.getFloatValue("line-height") * 0.84 + "pt");
+        styleHandler.updateNodeStyle();
       }
 
       container.appendChild(node);

--- a/java/src/pdf/dom/images/ImageExtractor.java
+++ b/java/src/pdf/dom/images/ImageExtractor.java
@@ -10,6 +10,12 @@ import org.w3c.dom.Node;
 
 public class ImageExtractor {
 
+  /**
+   * Extracts images from the given container node, giving them to an ImageSaver for saving on an
+   * external image host.
+   *
+   * @param containerNode The node to extract images from
+   */
   public static void extractImages(Node containerNode) {
     List<ImageSaver> imageSavers = new ArrayList<>();
 

--- a/java/src/pdf/dom/images/ImageExtractor.java
+++ b/java/src/pdf/dom/images/ImageExtractor.java
@@ -1,14 +1,22 @@
 package pdf.dom.images;
 
-import static pdf.dom.images.ImageSaver.saveBase64Image;
-
 import api.exceptions.APIBadRequestException;
+import java.lang.Thread.UncaughtExceptionHandler;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 public class ImageExtractor {
 
   public static void extractImages(Node containerNode) {
+    List<ImageSaver> imageSavers = new ArrayList<>();
+
+    UncaughtExceptionHandler exceptionHandler = (t, e) -> {
+      throw new APIBadRequestException("Could no handle the images in the PDF");
+    };
+
     for (int childIndex = 0; childIndex < containerNode.getChildNodes().getLength(); childIndex++) {
       Node node = containerNode.getChildNodes().item(childIndex);
       if (node.getNodeName().equals("img")) {
@@ -16,13 +24,22 @@ public class ImageExtractor {
         if (((Element) node).getAttribute("src") == null) {
           continue;
         }
-        // All images produced by DOM are base 64 encoded
-        String urlCode = saveBase64Image(((Element) node).getAttribute("src"));
-        if (urlCode == null) {
-          throw new APIBadRequestException("Could not handle the PDF");
-        }
-        ((Element) node).setAttribute("src", urlCode);
+
+        // Use threads to process all the images at the same time
+        ImageSaver imageSaver = new ImageSaver(((Element) node).getAttribute("src"), node);
+        imageSaver.setUncaughtExceptionHandler(exceptionHandler);
+        imageSavers.add(imageSaver);
+        imageSaver.start();
       }
+    }
+
+    while (imageSavers.size() > 0) {
+      // Sleep for a small amount of time to not use a lot of CPU
+      try {
+        Thread.sleep(50);
+      } catch (InterruptedException ignored) {
+      }
+      imageSavers = imageSavers.stream().filter(ImageSaver::isAlive).collect(Collectors.toList());
     }
   }
 }

--- a/java/src/pdf/dom/images/ImageSaver.java
+++ b/java/src/pdf/dom/images/ImageSaver.java
@@ -1,29 +1,43 @@
 package pdf.dom.images;
 
+import api.exceptions.APIBadRequestException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.InetSocketAddress;
 import java.net.Socket;
-import org.apache.http.Header;
 import org.apache.http.HttpException;
 import org.apache.http.HttpResponse;
 import org.apache.http.impl.io.DefaultHttpResponseParser;
 import org.apache.http.impl.io.HttpTransportMetricsImpl;
 import org.apache.http.impl.io.SessionInputBufferImpl;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 
-public class ImageSaver {
+public class ImageSaver extends Thread {
 
   public static final String BASEURL = "http://cdn.tobot.hummel.io:8080/images/";
+  private String base64;
+  private Node imageNode;
 
-  public static String saveBase64Image(String base64) {
+  public ImageSaver(String base64, Node imageNode) {
+    this.base64 = base64;
+    this.imageNode = imageNode;
+  }
+
+  @Override
+  public void run() {
+    ((Element) imageNode).setAttribute("src", saveBase64Image(base64));
+  }
+
+  private String saveBase64Image(String base64) {
     try {
       return makeSaveRequest(base64.substring(base64.indexOf(",") + 1));
     } catch (IOException | HttpException e) {
-      return null;
+      throw new APIBadRequestException("Could not handle the image");
     }
   }
 
-  private static String makeSaveRequest(String base64Image) throws IOException, HttpException {
+  private String makeSaveRequest(String base64Image) throws IOException, HttpException {
     Socket socket = new Socket();
     socket.connect(new InetSocketAddress("cdn.tobot.hummel.io", 8080));
 

--- a/java/src/pdf/dom/images/ImageSaver.java
+++ b/java/src/pdf/dom/images/ImageSaver.java
@@ -13,6 +13,11 @@ import org.apache.http.impl.io.SessionInputBufferImpl;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
+/**
+ * Saves given images to an external host and changes the content of the image nodes to links of
+ * the given image instead. Works as a thread so that the images can be saved in parallel saving
+ * a lot of uploading time
+ */
 public class ImageSaver extends Thread {
 
   public static final String BASEURL = "http://cdn.tobot.hummel.io:8080/images/";
@@ -29,6 +34,12 @@ public class ImageSaver extends Thread {
     ((Element) imageNode).setAttribute("src", saveBase64Image(base64));
   }
 
+  /**
+   * Saves a base 64 image
+   *
+   * @param base64 The base64 string of the image
+   * @return
+   */
   private String saveBase64Image(String base64) {
     try {
       return makeSaveRequest(base64.substring(base64.indexOf(",") + 1));
@@ -37,7 +48,15 @@ public class ImageSaver extends Thread {
     }
   }
 
-  private String makeSaveRequest(String base64Image) throws IOException, HttpException {
+  /**
+   * Makes a request to save the given image to the external host
+   *
+   * @param image The given image
+   * @return A URL for the image on the external host
+   * @throws IOException Problems writing to the socket
+   * @throws HttpException No content in response
+   */
+  private String makeSaveRequest(String image) throws IOException, HttpException {
     Socket socket = new Socket();
     socket.connect(new InetSocketAddress("cdn.tobot.hummel.io", 8080));
 
@@ -47,7 +66,7 @@ public class ImageSaver extends Thread {
     sessionInputBuffer.bind(socket.getInputStream());
     DefaultHttpResponseParser responseParser = new DefaultHttpResponseParser(sessionInputBuffer);
 
-    printWriter.write("POST /save.php HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nHost: cdn.tobot.hummel.io:8080\nContent-Length: " + (6 + base64Image.length()) + "\r\n\r\nimage=" + base64Image + "\r\n\r\n");
+    printWriter.write("POST /save.php HTTP/1.1\r\nContent-Type: application/x-www-form-urlencoded\r\nHost: cdn.tobot.hummel.io:8080\nContent-Length: " + (6 + image.length()) + "\r\n\r\nimage=" + image + "\r\n\r\n");
     printWriter.flush();
     HttpResponse httpResponse = responseParser.parse();
     if (sessionInputBuffer.available() == 0){

--- a/java/src/pdf/dom/images/ImageSaver.java
+++ b/java/src/pdf/dom/images/ImageSaver.java
@@ -38,7 +38,7 @@ public class ImageSaver extends Thread {
    * Saves a base 64 image
    *
    * @param base64 The base64 string of the image
-   * @return
+   * @return The url of the image on the image host
    */
   private String saveBase64Image(String base64) {
     try {

--- a/java/src/pdf/exercises/ExerciseFinder.java
+++ b/java/src/pdf/exercises/ExerciseFinder.java
@@ -56,7 +56,7 @@ public class ExerciseFinder {
    * @param node2 the second node
    * @return A boolean indicating if the nodes are on the same line
    */
-  private static boolean isOnSameLine(Node node1, Node node2) {
+  public static boolean isOnSameLine(Node node1, Node node2) {
     StyleHandler styleHandlerFirstNode = new StyleHandler(node1);
     StyleHandler styleHandlerSecondNode = new StyleHandler(node2);
 

--- a/java/src/pdf/exercises/ExerciseNumberingClassifier.java
+++ b/java/src/pdf/exercises/ExerciseNumberingClassifier.java
@@ -1,5 +1,7 @@
 package pdf.exercises;
 
+import static pdf.exercises.ExerciseFinder.isOnSameLine;
+
 import com.google.common.collect.Lists;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -32,6 +34,11 @@ public class ExerciseNumberingClassifier {
   private void classify(Node container) {
     for (int nodeIndex = 0; nodeIndex < container.getChildNodes().getLength(); nodeIndex++) {
       String nodeContent = container.getChildNodes().item(nodeIndex).getTextContent();
+      if (nodeIndex != 0 && isOnSameLine(container.getChildNodes().item(nodeIndex - 1),
+          container.getChildNodes().item(nodeIndex))) {
+        // Skip the things that are not at the start of the lines, they are not numberings
+        continue;
+      }
       numberingFormats.keySet().stream().filter(nodeContent::matches).forEach(numberingFormat ->
           numberingFormats.put(numberingFormat, numberingFormats.get(numberingFormat) + 1));
     }


### PR DESCRIPTION
Image saver is no a thread and image extractor spawns a process for each one. This means that all the image uploads to the image host is done in parrallel. For the test PDF I used which earlier took around 60 seconds, the improved upload time is now around 5 seconds