### PR TITLE
Turn on the quiet flag for cobertura

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -132,6 +132,7 @@
                 <artifactId>cobertura-maven-plugin</artifactId>
                 <version>2.7</version>
                 <configuration>
+                    <quiet>true</quiet>
                     <formats>
                         <format>html</format>
                         <format>xml</format>


### PR DESCRIPTION
Turns out there is a lot of errors when parsing java 8 syntaxes. We, therefore, turn on the quiet flag for the CodeCov to not complain that much.